### PR TITLE
Add Lightspeed Day 2 Automation for Summit Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# lb2958_aap_manifest
+# Summit Lightspeed Chatbot Lab
+
+Lab environment automation for bootstrapping AAP 2.5 deployed in Openshift with the Lightspeed Chatbot.
+
+This Ansible role uploads an AAP 2.6 manifest to an existing AAP installation and can optionally deploy Lightspeed as a Day 2 operation.
+
+## Requirements
+
+- An existing AAP installation on OpenShift
+- Access to the AAP manifest file
+- Proper OpenShift credentials with access to the AAP namespace
+
+## Usage
+
+### Set Env Vars for Lightspeed
+
+If you want to deploy Lightspeed with WCA integration, you can set the following environment variables before running the playbook:
+
+```bash
+export LIGHTSPEED_WCA_ENABLED=false
+export LIGHTSPEED_CHATBOT_TOKEN="your-chatbot-token"
+```
+
+### Create vars.yml from template and run playbook
+
+The easiest way to run this role is by using a vars.yml file:
+
+1. Copy the example vars file:
+   ```bash
+   cp vars.yml.example vars.yml
+   ```
+
+2. Edit the vars.yml file with your specific values:
+   ```bash
+   vi vars.yml
+   ```
+
+Required variables to change:
+- lb2958_aap_manifest_url or lb2958_aap_manifest_local_path
+- lb2958_aap_manifest_aap_hostname
+- lb2958_aap_manifest_aap_password
+- aap_namespace
+- aap_name
+- lightspeed_chatbot_url
+
+3. Run the playbook directly using ansible-playbook:
+   ```bash
+   ansible-playbook bootstrap-lightspeed-chatbot.yml -e @vars.yml
+   ```
+
+This approach allows you to keep your configuration separate from the code and easily update variables without modifying the playbook.
+
+> Note: It will take about 10 minutes for Lightspeed to deploy and registry with AAP.

--- a/bootstrap-lightspeed-chatbot.yml
+++ b/bootstrap-lightspeed-chatbot.yml
@@ -1,0 +1,8 @@
+---
+# Playbook to apply AAP manifest and optionally deploy Lightspeed
+- name: Apply AAP Manifest and Deploy Lightspeed
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Include tasks from main.yml
+      ansible.builtin.include_tasks: tasks/main.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,14 @@
 ---
-lb2958_aap_manifest_url: https://<CHANGEME>
-# lb2958_aap_manifest:
-#   username: <CHANGEME>
-#   password: <CHANGEME>
+# AAP Manifest can be provided either as a URL or a local file path
+# Option 1: URL to download the manifest
+lb2958_aap_manifest_url: https://placeholder
+
+# Option 2: Local path to the manifest file
+# lb2958_aap_manifest_local_path: /path/to/aap-manifest.zip
 
 lb2958_aap_manifest_aap_hostname: "{{ automation_controller_hostname }}"
 lb2958_aap_manifest_aap_username: admin
-lb2958_aap_manifest_aap_password: <CHANGEME>
+lb2958_aap_manifest_aap_password: placeholder
+
+# Enable Lightspeed deployment after AAP manifest has been applied
+deploy_lightspeed: false

--- a/roles/day2_get_admin/tasks/get_admin.yaml
+++ b/roles/day2_get_admin/tasks/get_admin.yaml
@@ -1,0 +1,8 @@
+---
+- name: Get AAP admin secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: secret
+    name: "{{ aap_admin_password_secret | default(aap_name + '-admin-password') }}"
+    namespace: "{{ aap_namespace }}"
+  register: aap_admin_secret

--- a/roles/day2_get_admin/tasks/main.yaml
+++ b/roles/day2_get_admin/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Get admin secret
+  ansible.builtin.include_tasks: get_admin.yaml

--- a/roles/day2_lightspeed/defaults/main.yml
+++ b/roles/day2_lightspeed/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# AAP Configuration for Lightspeed
+aap_name: aap
+aap_namespace: "{{ lookup('ansible.builtin.env', 'NAMESPACE') | default('aap') }}"
+api_version: 'aap.ansible.com/v1alpha1'
+hide_secrets: false
+require_valid_certs: true
+
+# Lightspeed Configuration
+lightspeed_name: "{{ aap_name }}-lightspeed"
+lightspeed_auth_config_secret_name: "{{ aap_name }}-lightspeed-auth-config"
+lightspeed_oauth_app_name: "{{ aap_name }}-lightspeed-oauth"
+lightspeed_user_name: ibm-user@redhat.com
+lightspeed_chatbot_url: https://granite-model-placeholder
+lightspeed_chatbot_model: granite3-1-8b
+lightspeed_chatbot_token: "{{ lookup('env', 'LIGHTSPEED_CHATBOT_TOKEN') }}"
+lightspeed_chatbot_config_secret_name: "{{ aap_name }}-lightspeed-chatbot-config"
+lightspeed_model_type: wca
+lightspeed_model_id: "{{ lookup('env', 'LIGHTSPEED_MODEL_ID') }}"
+lightspeed_model_url: "{{ lookup('env', 'LIGHTSPEED_MODEL_URL') }}"
+lightspeed_model_api_key: "{{ lookup('env', 'LIGHTSPEED_MODEL_API_KEY') }}"
+lightspeed_model_config_secret_name: "{{ aap_name }}-lightspeed-model-config"
+lightspeed_wca_enabled: "{{ lookup('env', 'LIGHTSPEED_WCA_ENABLED') | default(false) | bool }}"

--- a/roles/day2_lightspeed/tasks/lightspeed.yaml
+++ b/roles/day2_lightspeed/tasks/lightspeed.yaml
@@ -1,0 +1,169 @@
+---
+# Purpose: Deploy Lightspeed as a Day 2 operation
+# 1. Create OAuth2 Application and store the client_id and client_secret in a variable
+# 2. Create the lightspeed secrets using the auth_config_secret.yaml.j2 and model_config_secret.yaml.j2 templates, and store the secret names in variables
+# 3. Patch the AAP CR to adopt lightspeed
+# 4. Check that the lightspeed pod is running
+
+# -- Create OAuth2 application in AAP
+- name: Create Lightspeed OAuth2 application
+  ansible.platform.application:
+    gateway_hostname: "{{ aap_hostname }}"
+    gateway_username: "{{ aap_admin_user | default('admin') }}"
+    gateway_password: "{{ aap_admin_secret.resources[0].data.password | b64decode }}"
+    validate_certs: "{{ require_valid_certs | default(true) }}"
+    name: "{{ lightspeed_oauth_app_name }}"
+    organization: "Default"
+    client_type: "confidential"
+    authorization_grant_type: "authorization-code"
+    redirect_uris:
+      - http://temp/
+  register: lightspeed_oauth_result
+  no_log: "{{ hide_secrets }}"
+
+- name: Display Lightspeed OAuth Application Details
+  ansible.builtin.debug:
+    msg: "OAuth App Created: Client ID: {{ lightspeed_oauth_result.client_id }}, Secret: {{ lightspeed_oauth_result.client_secret }}"
+  no_log: "{{ hide_secrets }}"
+
+- name: Store Lightspeed OAuth credentials as a fact
+  ansible.builtin.set_fact:
+    lightspeed_oauth_client_id: "{{ lightspeed_oauth_result.client_id }}"
+    lightspeed_oauth_client_secret: "{{ lightspeed_oauth_result.client_secret }}"
+  no_log: "{{ hide_secrets }}"
+
+- name: Create auth and chatbot secrets for Lightspeed
+  kubernetes.core.k8s:
+    state: present
+    namespace: "{{ aap_namespace }}"
+    definition: "{{ lookup('template', 'secrets/' + item + '.j2') }}"
+  loop:
+    - lightspeed_auth_config_secret.yaml
+    - lightspeed_chatbot_config_secret.yaml
+
+- name: Create model config secret for Lightspeed if WCA is enabled
+  kubernetes.core.k8s:
+    state: present
+    namespace: "{{ aap_namespace }}"
+    definition: "{{ lookup('template', 'secrets/lightspeed_model_config_secret.yaml.j2') }}"
+  when:
+    - lightspeed_wca_enabled | bool
+    - lightspeed_model_url is defined and lightspeed_model_url | length > 0
+    - lightspeed_model_api_key is defined and lightspeed_model_api_key | length > 0
+    - lightspeed_model_id is defined and lightspeed_model_id | length > 0
+
+- name: Inject Lightspeed into AAP with WCA enabled
+  kubernetes.core.k8s:
+    merge_type: ["merge"]
+    definition:
+      apiVersion: '{{ api_version }}'
+      kind: AnsibleAutomationPlatform
+      metadata:
+        name: '{{ aap_name }}'
+        namespace: '{{ aap_namespace }}'
+      spec:
+        lightspeed:
+          disabled: false
+          image_pull_policy: Always
+          model_config_secret_name: '{{ lightspeed_model_config_secret_name }}'
+          auth_config_secret_name: '{{ lightspeed_auth_config_secret_name }}'
+          chatbot_config_secret_name: '{{ lightspeed_chatbot_config_secret_name }}'
+  when:
+    - lightspeed_wca_enabled | bool
+    - lightspeed_model_url is defined and lightspeed_model_url | length > 0
+    - lightspeed_model_api_key is defined and lightspeed_model_api_key | length > 0
+    - lightspeed_model_id is defined and lightspeed_model_id | length > 0
+
+- name: Inject Lightspeed into AAP without WCA
+  kubernetes.core.k8s:
+    merge_type: ["merge"]
+    definition:
+      apiVersion: '{{ api_version }}'
+      kind: AnsibleAutomationPlatform
+      metadata:
+        name: '{{ aap_name }}'
+        namespace: '{{ aap_namespace }}'
+      spec:
+        lightspeed:
+          disabled: false
+          image_pull_policy: Always
+          auth_config_secret_name: '{{ lightspeed_auth_config_secret_name }}'
+          chatbot_config_secret_name: '{{ lightspeed_chatbot_config_secret_name }}'
+  when: not (lightspeed_wca_enabled | bool) or not (lightspeed_model_url is defined and lightspeed_model_url | length > 0 and lightspeed_model_api_key is defined and lightspeed_model_api_key | length > 0 and lightspeed_model_id is defined and lightspeed_model_id | length > 0)
+
+- name: Wait for the AnsibleLightspeed CR to be fully operational
+  kubernetes.core.k8s_info:
+    api_version: lightspeed.ansible.com/v1alpha1
+    kind: AnsibleLightspeed
+    namespace: "{{ aap_namespace }}"
+    name: "{{ lightspeed_name }}"
+  register: ls_cr
+  retries: 60
+  delay: 15
+  until: >
+    ls_cr.resources | length > 0 and
+    ls_cr.resources[0].status is defined and
+    ls_cr.resources[0].status.URL is defined and
+    ls_cr.resources[0].status.URL | length > 0
+
+- name: Extract the OpenShift Route from AnsibleLightspeed status
+  ansible.builtin.set_fact:
+    lightspeed_url: "{{ ls_cr.resources[0].status.URL }}"
+
+- name: Display the AnsibleLightspeed URL
+  ansible.builtin.debug:
+    msg: "AnsibleLightspeed service is ready at: {{ lightspeed_url }}"
+
+# TODO - Temporary workaround
+- name: Scale down Gateway Operator Deployment
+  kubernetes.core.k8s:
+    state: present
+    wait: true
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "aap-gateway-operator-controller-manager"
+        namespace: "{{ aap_namespace }}"
+      spec:
+        replicas: 0
+
+- name: Patch OAuth2 application in AAP
+  ansible.platform.application:
+    gateway_hostname: "{{ aap_hostname }}"
+    gateway_username: "{{ aap_admin_user | default('admin') }}"
+    gateway_password: "{{ aap_admin_secret.resources[0].data.password | b64decode }}"
+    validate_certs: "{{ require_valid_certs | default(true) }}"
+    name: "{{ lightspeed_oauth_app_name }}"
+    organization: "Default"
+    redirect_uris:
+      - "{{ lightspeed_url }}/complete/aap/"
+
+# TODO - Temporary workaround
+- name: Scale up Gateway Operator Deployment
+  kubernetes.core.k8s:
+    state: present
+    wait: true
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "aap-gateway-operator-controller-manager"
+        namespace: "{{ aap_namespace }}"
+      spec:
+        replicas: 1
+
+- name: Verify AAP
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: '{{ api_version }}'
+      kind: AnsibleAutomationPlatform
+      metadata:
+        name: '{{ aap_name }}'
+        namespace: '{{ aap_namespace }}'
+    wait: true
+    wait_condition:
+      type: Successful
+      reason: Successful
+      status: "True"
+    wait_timeout: 1200

--- a/roles/day2_lightspeed/tasks/main.yaml
+++ b/roles/day2_lightspeed/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Deploy Lightspeed as a Day2 Operation
+  ansible.builtin.include_tasks: lightspeed.yaml

--- a/roles/day2_lightspeed/templates/lightspeed.yaml.j2
+++ b/roles/day2_lightspeed/templates/lightspeed.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: lightspeed.ansible.com/v1alpha1
+kind: AnsibleLightspeed
+metadata:
+  name: "{{ lightspeed_name }}"
+spec:
+{% if lightspeed_wca_enabled | bool and lightspeed_model_url is defined and lightspeed_model_url | length > 0 and lightspeed_model_api_key is defined and lightspeed_model_api_key | length > 0 and lightspeed_model_id is defined and lightspeed_model_id | length > 0 %}
+  model_config_secret_name: "{{ lightspeed_model_config_secret_name }}"
+{% endif %}
+  auth_config_secret_name: "{{ lightspeed_auth_config_secret_name }}"
+  chatbot_config_secret_name: "{{ lightspeed_chatbot_config_secret_name }}"
+  no_log: {{ hide_secrets }}

--- a/roles/day2_lightspeed/templates/secrets/lightspeed_auth_config_secret.yaml.j2
+++ b/roles/day2_lightspeed/templates/secrets/lightspeed_auth_config_secret.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ lightspeed_auth_config_secret_name }}
+  namespace: {{ aap_namespace }}
+stringData:
+  auth_api_url: "https://{{ aap_hostname }}"
+  auth_api_key: "{{ lightspeed_oauth_client_id }}"
+  auth_api_secret: "{{ lightspeed_oauth_client_secret }}"
+  auth_verify_ssl: "{{ require_valid_certs | default(true) }}"
+  auth_allowed_hosts: "*"
+type: Opaque

--- a/roles/day2_lightspeed/templates/secrets/lightspeed_chatbot_config_secret.yaml.j2
+++ b/roles/day2_lightspeed/templates/secrets/lightspeed_chatbot_config_secret.yaml.j2
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ lightspeed_chatbot_config_secret_name }}
+  namespace: {{ aap_namespace }}
+stringData:
+  chatbot_url: {{ lightspeed_chatbot_url }}
+  chatbot_model: {{ lightspeed_chatbot_model }}
+  chatbot_token: {{ lightspeed_chatbot_token }}
+type: Opaque

--- a/roles/day2_lightspeed/templates/secrets/lightspeed_model_config_secret.yaml.j2
+++ b/roles/day2_lightspeed/templates/secrets/lightspeed_model_config_secret.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ lightspeed_model_config_secret_name }}
+  namespace: {{ aap_namespace }}
+stringData:
+  username: {{ lightspeed_user_name }}
+  model_url: {{ lightspeed_model_url }}
+  model_api_key: {{ lightspeed_model_api_key }}
+  model_id: "{{ lightspeed_model_id }}"
+  model_type: "{{ lightspeed_model_type }}"
+type: Opaque

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,28 @@
 ---
+- name: Check if local manifest file exists
+  ansible.builtin.stat:
+    path: "{{ lb2958_aap_manifest_local_path | default('') }}"
+  register: local_manifest_stat
+  when: lb2958_aap_manifest_local_path is defined
+
+- name: Copy local manifest file
+  ansible.builtin.copy:
+    src: "{{ lb2958_aap_manifest_local_path }}"
+    dest: /tmp/aap-manifest.zip
+    remote_src: true
+  when:
+    - lb2958_aap_manifest_local_path is defined
+    - local_manifest_stat.stat.exists | default(false)
+
 - name: Fetch Automation Controller manifest file
   ansible.builtin.get_url:
     url: "{{ lb2958_aap_manifest_url }}"
     dest: /tmp/aap-manifest.zip
     username: "{{ lb2958_aap_manifest.username | default(omit) }}"
     password: "{{ lb2958_aap_manifest.password | default(omit) }}"
+  when:
+    - lb2958_aap_manifest_local_path is not defined or not local_manifest_stat.stat.exists | default(false)
+    - lb2958_aap_manifest_url is defined
 
 - name: Create AAP Auth token
   ansible.platform.token:
@@ -14,6 +32,7 @@
     gateway_hostname: "{{ lb2958_aap_manifest_aap_hostname }}"
     gateway_username: "{{ lb2958_aap_manifest_aap_username }}"
     gateway_password: "{{ lb2958_aap_manifest_aap_password }}"
+    validate_certs: "{{ require_valid_certs | default(true) }}"
   register: r_aap_token
   until: r_aap_token.failed == false
   retries: 10
@@ -25,7 +44,7 @@
       aap_controller_token: "{{ r_aap_token.ansible_facts.aap_token.token }}"
 
 - name: Save token in var
-  set_fact:
+  ansible.builtin.set_fact:
     _lb2958_aap_manifest_token: "{{ r_aap_token.ansible_facts.aap_token.token }}"
 
 - name: Inject AAP2 Controller manifest
@@ -35,7 +54,7 @@
     controller_username: "{{ lb2958_aap_manifest_aap_username }}"
     controller_oauthtoken: "{{ _lb2958_aap_manifest_token }}"
     controller_password: "{{ lb2958_aap_manifest_aap_password }}"
-    validate_certs: true
+    validate_certs: "{{ require_valid_certs | default(true) }}"
   register: r_aap_license
   until: not r_aap_license.failed
   retries: 30
@@ -46,3 +65,19 @@
     path: /tmp/aap-manifest.zip
     state: absent
 
+# Deploy Lightspeed as a Day 2 operation after AAP manifest has been applied
+- name: Set AAP hostname for Lightspeed configuration
+  ansible.builtin.set_fact:
+    aap_hostname: "{{ lb2958_aap_manifest_aap_hostname }}"
+    aap_admin_user: "{{ lb2958_aap_manifest_aap_username }}"
+    aap_admin_password: "{{ lb2958_aap_manifest_aap_password }}"
+
+- name: Get AAP admin credentials
+  ansible.builtin.import_role:
+    name: day2_get_admin
+  when: deploy_lightspeed | default(false) | bool
+
+- name: Configure AAP Lightspeed
+  ansible.builtin.import_role:
+    name: day2_lightspeed
+  when: deploy_lightspeed | default(false) | bool

--- a/vars.yml.example
+++ b/vars.yml.example
@@ -1,0 +1,33 @@
+---
+# AAP Connection Information
+lb2958_aap_manifest_aap_hostname: <CHANGEME>  # e.g., aap.example.com
+lb2958_aap_manifest_aap_username: admin
+lb2958_aap_manifest_aap_password: <CHANGEME>
+
+# AAP custom resource
+aap_name: aap
+aap_namespace: aap  # Namespace where AAP is deployed
+
+# Only needed if you have a custom admin password k8s secret
+#aap_admin_password_secret: custom-admin-password
+
+# Lightspeed Chatbot
+lightspeed_chatbot_url: https://granite3-1-8b-wisdom-model-staging.apps.stage2-west.v2dz.p1.openshiftapps.com/v1
+aap_name: myaap
+aap_namespace: chadams
+deploy_lightspeed: true
+require_valid_certs: false
+
+# Set to true to hide sensitive information in logs
+hide_secrets: true
+
+# AAP Manifest Configuration
+# Option 1: URL to download the manifest (comment out if using local file)
+lb2958_aap_manifest_url: https://<CHANGEME>/aap-manifest.zip
+# Uncomment if authentication is required for manifest download
+# lb2958_aap_manifest:
+#   username: <CHANGEME>
+#   password: <CHANGEME>
+
+# Option 2: Local path to the manifest file (comment out if using URL)
+# lb2958_aap_manifest_local_path: /path/to/aap-manifest.zip


### PR DESCRIPTION
# Summary

Lightspeed Day 2 Automation for Summit Lab

See README.md for details on how to use it.  Note that there is a vars.yml that needs to be created and 2 env vars that must be set before running the playbook.

## Usage

Set Env Var and create vars.yml from template

 ```bash
export LIGHTSPEED_WCA_ENABLED=false
export LIGHTSPEED_CHATBOT_TOKEN="your-chatbot-token"
 cp vars.yml.example vars.yml
 ```

Update vars.yml with valid values for the following:

- lb2958_aap_manifest_url or lb2958_aap_manifest_local_path
- lb2958_aap_manifest_aap_hostname
- lb2958_aap_manifest_aap_password
- aap_namespace
- aap_name
- lightspeed_chatbot_url

Run the playbook

```bash
ansible-playbook bootstrap-lightspeed-chatbot.yml -e @vars.yml
```