### PR TITLE
Add requirements.yml and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+vars.yml

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This Ansible role uploads an AAP 2.6 manifest to an existing AAP installation an
 - An existing AAP installation on OpenShift
 - Access to the AAP manifest file
 - Proper OpenShift credentials with access to the AAP namespace
+- Install required collections:
+  ```bash
+  ansible-galaxy collection install -r requirements.yml
+  ```
 
 ## Usage
 

--- a/bootstrap-lightspeed-chatbot.yml
+++ b/bootstrap-lightspeed-chatbot.yml
@@ -1,5 +1,5 @@
 ---
-# Playbook to apply AAP manifest and optionally deploy Lightspeed
+# Playbook to apply AAP manifest and deploy Lightspeed
 - name: Apply AAP Manifest and Deploy Lightspeed
   hosts: localhost
   gather_facts: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Mitesh The Mouse <mitsharm@redhat.com>
-  description: Upload AAP2.6 manifest
+  description: Upload AAP 2.5 manifest and Configure Ansible Lightspeed
   company: Red Hat
   license: GPLv3
   min_ansible_version: "2.1"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - name: kubernetes.core
+    version: ">=2.4.2"
+  - name: ansible.controller
+    version: "4.6.11"

--- a/vars.yml.example
+++ b/vars.yml.example
@@ -7,16 +7,16 @@ lb2958_aap_manifest_aap_password: <CHANGEME>
 # AAP custom resource
 aap_name: aap
 aap_namespace: aap  # Namespace where AAP is deployed
+require_valid_certs: false
 
 # Only needed if you have a custom admin password k8s secret
 #aap_admin_password_secret: custom-admin-password
 
 # Lightspeed Chatbot
 lightspeed_chatbot_url: https://granite3-1-8b-wisdom-model-staging.apps.stage2-west.v2dz.p1.openshiftapps.com/v1
-aap_name: myaap
-aap_namespace: chadams
-deploy_lightspeed: true
-require_valid_certs: false
+
+# (Optional)Specify Chatbot API Key as an ansible var instead of an env var
+# lightspeed_chatbot_token: <CHANGEME>
 
 # Set to true to hide sensitive information in logs
 hide_secrets: true


### PR DESCRIPTION
Follow-up for https://github.com/rhpds/lb2958_aap_manifest/pull/1 to add a requirements.yml to more easily install the required collections.  Also adds a .gitignore.

Note that instead of specifying the `LIGHTSPEED_CHATBOT_TOKEN`, it is possible to just set it as an ansible variable in the vars.yml file:

```yaml
---
lightspeed_chatbot_token: <value>
```